### PR TITLE
Added removal of semicolon before closing bracket

### DIFF
--- a/minify.php
+++ b/minify.php
@@ -20,8 +20,8 @@ function minify( $css ) {
 	// Remove ; before }
 	$css = preg_replace( '/;(?=\s*})/', '', $css );
 
-	// Remove space after , : ; { } */
-	$css = preg_replace( '/(,|:|;|\{|}|\*\/) /', '$1', $css );
+	// Remove space after , : ; { } */ >
+	$css = preg_replace( '/(,|:|;|\{|}|\*\/|>) /', '$1', $css );
 
 	// Remove space before , ; { } ( ) >
 	$css = preg_replace( '/ (,|;|\{|}|\(|\)|>)/', '$1', $css );


### PR DESCRIPTION
We can minify even further by removing trailing semicolon from the last property in a declaration block.

```
body { color: #eee; }
```

May become

```
body { color: #eee }
```
