### PR TITLE
Remove multiple-line comments

### DIFF
--- a/minify.php
+++ b/minify.php
@@ -15,7 +15,7 @@ function minify( $css ) {
 
 	// Remove comment blocks, everything between /* and */, unless
 	// preserved with /*! ... */
-	$css = preg_replace( '/\/\*[^\!]([^\*]|[\s]|(\*([^\/]|[\s])))*\*\//', '', $css );
+	$css = preg_replace( '/\/\*([^\!]|\s([^\*]|\s|(\*([^\/]|\s))))*\*\//', '', $css );
 	
 	// Remove ; before }
 	$css = preg_replace( '/;(?=\s*})/', '', $css );


### PR DESCRIPTION
Hey Gary,

During testing with the regex for removing comment blocks I found that one-line comment blocks were removed while multi-line comments remained. After some more research and tinkering, I ended up with this regex and thought I would pass it along. Tested with http://www.phpliveregex.com/ and in PHP v5.3.7.
